### PR TITLE
note that NEOMUTT_TEST_DIR must be an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ See also: [Test code coverage](https://coveralls.io/github/neomutt/neomutt)
 ```sh
 git clone https://github.com/neomutt/neomutt
 git clone https://github.com/neomutt/neomutt-test-files
+
+# NEOMUTT_TEST_DIR must be an absolute path or a test will fail
 export NEOMUTT_TEST_DIR="$HOME/neomutt-test-files"
+
 (cd neomutt-test-files; ./setup.sh)
 ```
 


### PR DESCRIPTION
Hi, I set up neomutt to autobuild in buildbot when there are changes in the git repo.

Although I figured it out, it would have been helpful to have a note that the NEOMUTT_TEST_DIR should be an absolute path.
(The test "test_mutt_file_resolve_symlink" fails if NEOMUTT_TEST_DIR env variable has a value like ../neomutt-test-dir.)

  So here is a pull request with that note.

