### PR TITLE
Also `/bin/sh`ify restore.sh

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
 chmod +rwx maildir/damson
 chmod +rw mbox/endive.mbox
 rm -fr tmp/*
-


### PR DESCRIPTION
setup.sh seems to've been `sh`ified in the aptly-named 1ee274e9ae1330fb901eb7b8275b3079d7869222, but `restore.sh` not so